### PR TITLE
Set closing_msg to 0

### DIFF
--- a/src/RPXLoading.cpp
+++ b/src/RPXLoading.cpp
@@ -38,8 +38,9 @@ DECL_FUNCTION(int32_t, HBM_NN_ACP_ACPGetTitleMetaXmlByDevice, uint32_t titleid_u
         snprintf(metaxml->shortname_en, sizeof(metaxml->shortname_en), "%s", gReplacementInfo.rpxReplacementInfo.metaInformation.shortname);
         snprintf(metaxml->publisher_en, sizeof(metaxml->publisher_en), "%s", gReplacementInfo.rpxReplacementInfo.metaInformation.author);
 
-        // Disbale the emanual
-        metaxml->e_manual = 0;
+        // Disable the emanual
+        metaxml->e_manual    = 0;
+        metaxml->closing_msg = 0;
 
         return 0;
     }


### PR DESCRIPTION
Sets the closing_msg in metaxml to 0.

Currently the HBM uses the value of the last none-homebrew title launched, therefore when closing homebrew from the HBM you will sometimes get the confirmation msg and sometimes will not.

Steps to reproduce issue using homebrew_on_menu plugin:
Launch and close a game that doesn't have the close confirm dialog (or coldboot to Wii U Menu) -> Launch and close a homebrew from the HBM - notice no dialog -> Launch and close a game that does have the close confirm dialog -> Launch and close a homebrew from the HBM - notice now the dialog appears.